### PR TITLE
Overhaul algorithm, add 28 day history, support better data resolution, refactor a lot of stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ __pycache__/
 
 # Test files
 date_test.py
-last_post_data_notifier.json
+last_post_data.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ __pycache__/
 # Test files
 date_test.py
 last_post_data.json
-post_data.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ __pycache__/
 # Test files
 date_test.py
 last_post_data.json
+post_data.json

--- a/.idea/dictionaries/User.xml
+++ b/.idea/dictionaries/User.xml
@@ -9,6 +9,7 @@
       <w>cryptocurrency</w>
       <w>dbnavigator</w>
       <w>fromtimestamp</w>
+      <w>mins</w>
       <w>perc</w>
       <w>pycache</w>
       <w>repost</w>

--- a/.idea/dictionaries/User.xml
+++ b/.idea/dictionaries/User.xml
@@ -8,10 +8,12 @@
       <w>cryptocorn</w>
       <w>cryptocurrency</w>
       <w>dbnavigator</w>
+      <w>fromtimestamp</w>
       <w>perc</w>
       <w>pycache</w>
       <w>repost</w>
       <w>reposting</w>
+      <w>strftime</w>
       <w>tweakable</w>
       <w>webhook</w>
     </words>

--- a/.idea/dictionaries/User.xml
+++ b/.idea/dictionaries/User.xml
@@ -8,6 +8,7 @@
       <w>cryptocorn</w>
       <w>cryptocurrency</w>
       <w>dbnavigator</w>
+      <w>perc</w>
       <w>pycache</w>
       <w>repost</w>
       <w>reposting</w>

--- a/analysis.py
+++ b/analysis.py
@@ -1,11 +1,7 @@
-from datetime import datetime
-
-from constants import SlackColourThresholds
 from stats import HourData
-from coinbase import Currency
 from history import History
 
-class Misc:
+class Analysis:
     @staticmethod
     def should_post(history: History, stats: HourData, prices: list, threshold: float):
         if history.rising != stats.is_diff_positive:
@@ -39,30 +35,3 @@ class Misc:
         else:
             print(f"Does not beat new threshold price: ({stats.cur_price:.0f}/{new_threshold:.0f})")
             return False
-
-    @staticmethod
-    def format_stat(stat: HourData, stats: HourData, text_pretext: str, pretext=None):
-        diff = stats.cur_price - stat.cur_price
-        diff /= stat.cur_price
-        diff *= 100
-
-        if diff > SlackColourThresholds.GOOD:
-            colour = "good"
-        elif diff > SlackColourThresholds.NEUTRAL:
-            colour = ""
-        elif diff > SlackColourThresholds.WARNING:
-            colour = "warning"
-        else:
-            colour = "danger"
-
-        text = f"{text_pretext}{Currency.SECONDARY_CURRENCY_SYMBOL}{stat.cur_price:,.0f} ({diff:+.2f}%)"
-        attachment = {"fallback": "some price changes", "text": text, "color": colour}
-        if pretext is not None:
-            attachment['pretext'] = pretext
-
-        return attachment
-
-    @staticmethod
-    def cur_time_hours():
-        cur_time = datetime.utcnow()
-        return cur_time.replace(minute=0, second=0, microsecond=0)

--- a/analysis.py
+++ b/analysis.py
@@ -35,3 +35,26 @@ class Analysis:
         else:
             print(f"Does not beat new threshold price: ({stats.cur_price:.0f}/{new_threshold:.0f})")
             return False
+
+    @staticmethod
+    def ema_checks(stats: HourData, history: History, ema_threshold: float, reset_perc: float):
+        if stats.ema_percent_diff_positive > ema_threshold:
+            print(f"Current price is outside threshold difference ({stats.formatted_info()})")
+            return False
+
+        print(f"Current price not outside threshold ({stats.formatted_info()})")
+
+        # If EMA hasn't been reset then check whether we should reset it
+        if not history.ema_reset:
+            if history.rising:
+                target = history.price * (1 - reset_perc / 100)
+                should_reset = stats.ema > target
+            else:
+                target = history.price * (1 + reset_perc / 100)
+                should_reset = stats.ema < target
+
+            if should_reset:
+                history.ema_reset = True
+                history.save()
+
+        return True

--- a/coinbase.py
+++ b/coinbase.py
@@ -56,8 +56,12 @@ class Coinbase:
     def price_days_ago(cls, days: int):
         time_ago = datetime.utcnow() - timedelta(days=days)
 
-        historical_data = cls.__get_historical_prices(time_ago, time_ago, cls.SECS_IN_MINUTE)
-        print(historical_data)
+        historical_data = cls.__get_historical_prices(time_ago - timedelta(minutes=1), time_ago, cls.SECS_IN_MINUTE)
+        historical_time = historical_data[0][0]
+        historical_price = historical_data[0][3]
+
+        print(f"Price {days} days ago was {Currency.SECONDARY_CURRENCY_SYMBOL}{historical_price} (exact time: " + datetime.fromtimestamp(historical_time).strftime("%d/%m/%Y - %H:%M") + ")")
+        return historical_price
 
     """Retrieve the un filtered results from coinbase according to the interval"""
     def __retrieve_from_coinbase(self):

--- a/coinbase.py
+++ b/coinbase.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import json
 from enum import Enum
 
+import sys
 import requests
 
 class Intervals(Enum):
@@ -34,7 +35,8 @@ class Coinbase:
             time_diff = self.data[i]['time'] - self.data[i + 1]['time']
             assert time_diff == 60 * self.interval
 
-        self.latest_price = self.data[0]['open']
+    def latest_price(self):
+        return self.data[0]['open']
 
     """Return a list of the last prices in reverse order (using open)"""
     def price_list(self):

--- a/coinbase.py
+++ b/coinbase.py
@@ -1,14 +1,29 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
+import requests
 
 class Coinbase:
-    def __init__(self, json_text: str):
+    API_URL = "https://api.pro.coinbase.com"
+    CANDLES_TO_RETRIEVE = 300
+
+    def __init__(self):
+        # Time param info for request
+        time_now = datetime.utcnow()
+        time_start = time_now - timedelta(hours=self.CANDLES_TO_RETRIEVE)  # CB should give 300 results, lets make sure of it
+        params = {
+            "start": time_start.isoformat(),
+            "end": time_now.isoformat(),
+            "granularity": 3600
+        }
+
+        # Send request
+        json_text = requests.get(f"{self.API_URL}/products/{Currency.CURRENCY_PAIR}/candles", params=params).text
         historical_data = json.loads(json_text)
 
+        # Parse https://docs.pro.coinbase.com/#get-historic-rates
         self.data = []
         for entry in historical_data:
             self.data.append({
-                # https://docs.pro.coinbase.com/#get-historic-rates
                 "time": entry[0],
                 "low": entry[1],
                 "high": entry[2],
@@ -38,3 +53,11 @@ class Coinbase:
         for entry in self.data:
             time_formatted = datetime.fromtimestamp(entry['time']).strftime("[%d/%m/%Y] %H:%M:%S")
             print(time_formatted + " - " + str(entry['open']))
+
+class Currency:
+    PRIMARY_CURRENCY = "BTC"
+    PRIMARY_CURRENCY_LONG = "Bitcoin"
+    SECONDARY_CURRENCY = "USD"
+    SECONDARY_CURRENCY_SYMBOL = "$"
+
+    CURRENCY_PAIR = f"{PRIMARY_CURRENCY}-{SECONDARY_CURRENCY}"

--- a/coinbase.py
+++ b/coinbase.py
@@ -1,24 +1,22 @@
 from datetime import datetime, timedelta
 import json
+from enum import Enum
+
+import sys
 import requests
+
+class Intervals(Enum):
+    HOUR = 60
+    MINUTE_15 = 15
+    MINUTE_5 = 5
 
 class Coinbase:
     API_URL = "https://api.pro.coinbase.com"
     CANDLES_TO_RETRIEVE = 300
+    interval = Intervals.MINUTE_15.value
 
     def __init__(self):
-        # Time param info for request
-        time_now = datetime.utcnow()
-        time_start = time_now - timedelta(hours=self.CANDLES_TO_RETRIEVE)  # CB should give 300 results, lets make sure of it
-        params = {
-            "start": time_start.isoformat(),
-            "end": time_now.isoformat(),
-            "granularity": 3600
-        }
-
-        # Send request
-        json_text = requests.get(f"{self.API_URL}/products/{Currency.CURRENCY_PAIR}/candles", params=params).text
-        historical_data = json.loads(json_text)
+        historical_data = self.__retrieve_from_coinbase()
 
         # Parse https://docs.pro.coinbase.com/#get-historic-rates
         self.data = []
@@ -35,7 +33,7 @@ class Coinbase:
         # Ensure timestamps are every hour
         for i in range(len(self.data) - 1):
             time_diff = self.data[i]['time'] - self.data[i + 1]['time']
-            assert time_diff == 3600
+            assert time_diff == 60 * self.interval
 
     def latest_price(self):
         return self.data[0]['open']
@@ -53,6 +51,36 @@ class Coinbase:
         for entry in self.data:
             time_formatted = datetime.fromtimestamp(entry['time']).strftime("[%d/%m/%Y] %H:%M:%S")
             print(time_formatted + " - " + str(entry['open']))
+
+    """Retrieve the un filtered results from coinbase according to the interval"""
+    def __retrieve_from_coinbase(self):
+        # Time param info for request
+        time_delta = timedelta(minutes=self.CANDLES_TO_RETRIEVE * self.interval)
+        time_now = datetime.utcnow()
+        time_start = time_now - time_delta
+
+        params = {
+            "granularity": 60 * self.interval
+        }
+        historical_data = []
+
+        # Send request
+        print(f"Retrieving data from coinbase (Interval: {self.interval})")
+        for i in range(round(Intervals.HOUR.value / self.interval)):
+            params["start"] = time_start.isoformat()
+            params["end"] = time_now.isoformat()
+
+            json_text = requests.get(f"{self.API_URL}/products/{Currency.CURRENCY_PAIR}/candles", params=params).text
+            historical_data += json.loads(json_text)
+
+            time_now -= time_delta
+            time_start -= time_delta
+
+            # Ugly hack
+            if i == 0:
+                time_now -= timedelta(minutes=self.interval)
+
+        return historical_data
 
 class Currency:
     PRIMARY_CURRENCY = "BTC"

--- a/coinbase.py
+++ b/coinbase.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import json
 from enum import Enum
 
-import sys
 import requests
 
 class Intervals(Enum):
@@ -20,7 +19,7 @@ class Coinbase:
 
         # Parse https://docs.pro.coinbase.com/#get-historic-rates
         self.data = []
-        for entry in historical_data:
+        for entry in historical_data[::round(Intervals.HOUR.value / self.interval)]:
             self.data.append({
                 "time": entry[0],
                 "low": entry[1],
@@ -32,8 +31,9 @@ class Coinbase:
 
         # Ensure timestamps are every hour
         for i in range(len(self.data) - 1):
+            # print(datetime.fromtimestamp(self.data[i]['time']).strftime("%d/%m/%Y - %H:%M"))
             time_diff = self.data[i]['time'] - self.data[i + 1]['time']
-            assert time_diff == 60 * self.interval
+            assert time_diff == 3600
 
     def latest_price(self):
         return self.data[0]['open']
@@ -65,7 +65,7 @@ class Coinbase:
         historical_data = []
 
         # Send request
-        print(f"Retrieving data from coinbase (Interval: {self.interval})")
+        print(f"Retrieving data from coinbase (Interval: {self.interval}m)")
         for i in range(round(Intervals.HOUR.value / self.interval)):
             params["start"] = time_start.isoformat()
             params["end"] = time_now.isoformat()

--- a/coinbase.py
+++ b/coinbase.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import json
 from enum import Enum
 
-import sys
 import requests
 
 class Intervals(Enum):
@@ -35,8 +34,7 @@ class Coinbase:
             time_diff = self.data[i]['time'] - self.data[i + 1]['time']
             assert time_diff == 60 * self.interval
 
-    def latest_price(self):
-        return self.data[0]['open']
+        self.latest_price = self.data[0]['open']
 
     """Return a list of the last prices in reverse order (using open)"""
     def price_list(self):

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,12 @@
+class SlackColourThresholds:
+    GOOD = 1
+    NEUTRAL = 0
+    WARNING = -1
+
+class SlackImages:
+    UP = "https://i.imgur.com/2PVZ0l1.png"
+    DOWN = "https://i.imgur.com/21sDn3D.png"
+
+    @classmethod
+    def get_image(cls, up: bool):
+        return cls.UP if up else cls.DOWN

--- a/history.py
+++ b/history.py
@@ -15,16 +15,11 @@ class History:
 
                 self.price = last_post['price']
                 self.rising = last_post['rising']
-                self.rising_str = "rising" if self.rising else "falling"
-
-                self.loaded = True
         except IOError:
             print("Couldn't load file, using default values")
             self.ema_reset = True
             self.price = None
             self.rising = True
-            self.rising_str = "ERR"
-            self.loaded = False
 
     def save(self):
         print(f"Updating {self.file_name}")

--- a/history.py
+++ b/history.py
@@ -1,0 +1,41 @@
+import json
+
+class History:
+    def __init__(self, file: str,):
+        self.file_name = file
+        print("Loading script history data")
+
+        try:
+            with open(file, "r") as file:
+                # Read file
+                data = json.loads(file.read())
+                last_post = data['last_post']
+
+                self.ema_reset = data['ema_reset']
+
+                self.price = last_post['price']
+                self.rising = last_post['rising']
+                self.rising_str = "rising" if self.rising else "falling"
+
+                self.loaded = True
+        except IOError:
+            print("Couldn't load file, using default values")
+            self.ema_reset = True
+            self.price = None
+            self.rising_str = True
+            self.rising_str = "ERR"
+            self.loaded = False
+
+    def save(self):
+        print(f"Updating {self.file_name}")
+
+        new_data = {
+            'ema_reset': self.ema_reset,
+            'last_post': {
+                'price': self.price,
+                'rising': self.rising
+            }
+        }
+
+        with open(self.file_name, "w") as f:
+            json.dump(new_data, f, indent=4)

--- a/history.py
+++ b/history.py
@@ -22,7 +22,7 @@ class History:
             print("Couldn't load file, using default values")
             self.ema_reset = True
             self.price = None
-            self.rising_str = True
+            self.rising = True
             self.rising_str = "ERR"
             self.loaded = False
 

--- a/misc.py
+++ b/misc.py
@@ -14,25 +14,25 @@ class Misc:
 
         if history.ema_reset:
             return True
-        else:
-            # Allow if increase is greater again
-            print("Price has not gone back within the EMA threshold since the last post")
-            if history.rising:
-                required_perc_diff = (1 + threshold / 100)
-                threshold_sign_str = "above"
-            else:
-                required_perc_diff = (1 - threshold / 100)
-                threshold_sign_str = "below"
 
-            new_threshold = history.price * required_perc_diff
-            print(f"To post again the current price must be {threshold_sign_str}: {new_threshold:.0f}")
-            if (history.rising and stats.cur_price > new_threshold) or \
-                    (not history.rising and stats.cur_price < new_threshold):
-                print(f"Beats new threshold price ({stats.cur_price:.0f}/{new_threshold:.0f})")
-                return True
-            else:
-                print(f"Does not beat new threshold price: ({stats.cur_price:.0f}/{new_threshold:.0f})")
-                return False
+        # Allow if increase is greater again
+        print("Price has not gone back within the EMA threshold since the last post")
+        if history.rising:
+            required_perc_diff = (1 + threshold / 100)
+            threshold_sign_str = "above"
+        else:
+            required_perc_diff = (1 - threshold / 100)
+            threshold_sign_str = "below"
+
+        new_threshold = history.price * required_perc_diff
+        print(f"To post again the current price must be {threshold_sign_str}: {new_threshold:.0f}")
+        if (history.rising and stats.cur_price > new_threshold) or \
+                (not history.rising and stats.cur_price < new_threshold):
+            print(f"Beats new threshold price ({stats.cur_price:.0f}/{new_threshold:.0f})")
+            return True
+        else:
+            print(f"Does not beat new threshold price: ({stats.cur_price:.0f}/{new_threshold:.0f})")
+            return False
 
     @staticmethod
     def format_stat(stat: HourData, stats: HourData, text_pretext: str, pretext=None):

--- a/misc.py
+++ b/misc.py
@@ -1,5 +1,30 @@
 from datetime import datetime
 
+from notifier import SlackColourThresholds
+from stats import TimeIntervalData
+from coinbase import Currency
+
+def format_stat(stat: TimeIntervalData, stats: TimeIntervalData, text_pretext: str, pretext=None):
+    diff = stats.cur_price - stat.cur_price
+    diff /= stat.cur_price
+    diff *= 100
+
+    if diff > SlackColourThresholds.GOOD:
+        colour = "good"
+    elif diff > SlackColourThresholds.NEUTRAL:
+        colour = ""
+    elif diff > SlackColourThresholds.WARNING:
+        colour = "warning"
+    else:
+        colour = "danger"
+
+    text = f"{text_pretext}{Currency.SECONDARY_CURRENCY_SYMBOL}{stat.cur_price:,.0f} ({diff:+.2f}%)"
+    attachment = {"fallback": "some price changes", "text": text, "color": colour}
+    if pretext is not None:
+        attachment['pretext'] = pretext
+
+    return attachment
+
 def cur_time_hours():
     cur_time = datetime.utcnow()
     return cur_time.replace(minute=0, second=0, microsecond=0)

--- a/misc.py
+++ b/misc.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+def cur_time_hours():
+    cur_time = datetime.utcnow()
+    return cur_time.replace(minute=0, second=0, microsecond=0)

--- a/misc.py
+++ b/misc.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 
 from constants import SlackColourThresholds
-from stats import TimeIntervalData
+from stats import HourData
 from coinbase import Currency
 from history import History
 
 class Misc:
     @staticmethod
-    def should_post(history: History, stats: TimeIntervalData, threshold: float):
+    def should_post(history: History, stats: HourData, threshold: float):
         if history.rising != stats.is_diff_positive:
             print(f"Last change was in the opposite direction")
             return True
@@ -35,7 +35,7 @@ class Misc:
                 return False
 
     @staticmethod
-    def format_stat(stat: TimeIntervalData, stats: TimeIntervalData, text_pretext: str, pretext=None):
+    def format_stat(stat: HourData, stats: HourData, text_pretext: str, pretext=None):
         diff = stats.cur_price - stat.cur_price
         diff /= stat.cur_price
         diff *= 100

--- a/misc.py
+++ b/misc.py
@@ -6,7 +6,7 @@ from coinbase import Currency
 from history import History
 
 def should_post(history: History, stats: TimeIntervalData, threshold: float):
-    if history.rising != stats.diff_positive:
+    if history.rising != stats.is_diff_positive:
         print(f"Last change was in the opposite direction")
         return True
 

--- a/misc.py
+++ b/misc.py
@@ -3,6 +3,34 @@ from datetime import datetime
 from notifier import SlackColourThresholds
 from stats import TimeIntervalData
 from coinbase import Currency
+from history import History
+
+def should_post(history: History, stats: TimeIntervalData, threshold: float):
+    if history.rising != stats.diff_positive:
+        print(f"Last change was in the opposite direction")
+        return True
+
+    if history.ema_reset:
+        return True
+    else:
+        # Allow if increase is greater again
+        print("Price has not gone back within the EMA threshold since the last post")
+        if history.rising:
+            required_perc_diff = (1 + threshold / 100)
+            threshold_sign_str = "above"
+        else:
+            required_perc_diff = (1 - threshold / 100)
+            threshold_sign_str = "below"
+
+        new_threshold = history.price * required_perc_diff
+        print(f"To post again the current price must be {threshold_sign_str}: {new_threshold:.0f}")
+        if (history.rising and stats.cur_price > new_threshold) or \
+                (not history.rising and stats.cur_price < new_threshold):
+            print(f"Beats new threshold price ({stats.cur_price:.0f}/{new_threshold:.0f})")
+            return True
+        else:
+            print(f"Does not beat new threshold price: ({stats.cur_price:.0f}/{new_threshold:.0f})")
+            return False
 
 def format_stat(stat: TimeIntervalData, stats: TimeIntervalData, text_pretext: str, pretext=None):
     diff = stats.cur_price - stat.cur_price

--- a/misc.py
+++ b/misc.py
@@ -7,10 +7,16 @@ from history import History
 
 class Misc:
     @staticmethod
-    def should_post(history: History, stats: HourData, threshold: float):
+    def should_post(history: History, stats: HourData, prices: list, threshold: float):
         if history.rising != stats.is_diff_positive:
             print(f"Last change was in the opposite direction")
             return True
+
+        # Hour change must reflect EMA change
+        risen_hour = stats.cur_price - prices[1]
+        if risen_hour != stats.is_diff_positive:
+            print("Hourly change does not agree with EMA change")
+            return False
 
         if history.ema_reset:
             return True

--- a/misc.py
+++ b/misc.py
@@ -13,7 +13,7 @@ class Misc:
             return True
 
         # Hour change must reflect EMA change
-        risen_hour = stats.cur_price - prices[1]
+        risen_hour = (stats.cur_price - prices[1]) > 0
         if risen_hour != stats.is_diff_positive:
             print("Hourly change does not agree with EMA change")
             return False

--- a/misc.py
+++ b/misc.py
@@ -13,7 +13,7 @@ class Misc:
             return True
 
         # Hour change must reflect EMA change
-        risen_hour = (stats.cur_price - prices[1]) > 0
+        risen_hour = stats.cur_price > prices[1]
         if risen_hour != stats.is_diff_positive:
             print("Hourly change does not agree with EMA change")
             return False

--- a/notifier.py
+++ b/notifier.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 
 from history import History
-from misc import Misc
+from analysis import Analysis
 from coinbase import Coinbase
 from slack import Slack
 from stats import HourData
@@ -68,7 +68,7 @@ if stats.ema_percent_diff_positive < EMA_THRESHOLD_PERCENT:
 
 print(f"Current price is outside threshold difference ({stats.formatted_info()})")
 
-if not Misc.should_post(history, stats, prices, EMA_THRESHOLD_PERCENT):
+if not Analysis.should_post(history, stats, prices, EMA_THRESHOLD_PERCENT):
     sys.exit(1)
 
 print("Posting to slack")

--- a/notifier.py
+++ b/notifier.py
@@ -20,8 +20,6 @@ parser.add_argument("--ema", "-e", default=26, type=int,
                     help="Number of hours for EMA calculation")
 parser.add_argument("--threshold", "-t", default=2.5, type=float,
                     help="Amount current price needs to be above EMA")
-parser.add_argument("--cooldown", "-cd", default=6, type=int,
-                    help="Number of hours to wait before reposting")
 parser.add_argument("--json-name", "-j",
                     help="Name of the JSON file to store with extension (use this if you're running the script multiple"
                          "times with different parameters)")
@@ -32,7 +30,6 @@ args = parser.parse_args()
 # Configurable Constants
 EMA_THRESHOLD_PERCENT = args.threshold
 EMA_NUM_HOURS = args.ema
-HOURS_BETWEEN_POSTS = args.cooldown
 
 BOT_NAME = args.name
 SLACK_CHANNEL = args.channel

--- a/notifier.py
+++ b/notifier.py
@@ -79,9 +79,9 @@ stats_1_hour = TimeIntervalData(prices, EMA_NUM_HOURS, 1)
 stats_24_hour = TimeIntervalData(prices, EMA_NUM_HOURS, 24)
 stats_7_day = TimeIntervalData(prices, EMA_NUM_HOURS, 24 * 7)
 
-sign_str = "up" if stats.diff_positive else "down"
+sign_str = "up" if stats.is_diff_positive else "down"
 attachment_pretext = f"{Currency.PRIMARY_CURRENCY_LONG}'s price has gone {sign_str}. Current price: {Currency.SECONDARY_CURRENCY_SYMBOL}{stats.cur_price:,.0f}"
-image_url = PRICE_UP_IMAGE if stats.diff_positive else PRICE_DOWN_IMAGE
+image_url = PRICE_UP_IMAGE if stats.is_diff_positive else PRICE_DOWN_IMAGE
 
 # noinspection PyListCreation
 attachments = []
@@ -93,6 +93,9 @@ attachments.append(format_stat(stats_7_day, stats, "Price 7 days ago:      "))
 print("Posting to slack")
 Slack.post_to_slack(BOT_NAME, image_url, "", attachments, SLACK_URL, SLACK_CHANNEL)
 
+history.price = stats.cur_price
+history.rising = stats.is_diff_positive
+history.ema_reset = False
 history.save()
 
 print("Done")

--- a/notifier.py
+++ b/notifier.py
@@ -20,8 +20,10 @@ parser.add_argument("--ema", "-e", default=26, type=int,
                     help="Number of hours for EMA calculation")
 parser.add_argument("-i", "--interval", default=60, type=int, choices=[5, 15, 60],
                     help="Resolution of data to fetch from coinbase (minutes)")
-parser.add_argument("--threshold", "-t", default=2.5, type=float,
-                    help="Amount current price needs to be above EMA")
+parser.add_argument("--threshold-ema", "-te", default=2.5, type=float,
+                    help="Amount current price needs to be above/below the EMA")
+parser.add_argument("--threshold-reset", "-tr", default=1.25, type=float,
+                    help="Amount EMA price needs to be within last post price to reset")
 parser.add_argument("--json-name", "-j",
                     help="Name of the JSON file to store with extension (use this if you're running the script multiple"
                          "times with different parameters)")
@@ -30,8 +32,9 @@ args = parser.parse_args()
 
 # region Constants
 # Configurable Constants
-EMA_THRESHOLD_PERCENT = args.threshold
+EMA_THRESHOLD_PERCENT = args.threshold_ema
 EMA_NUM_HOURS = args.ema
+EMA_RESET_PERCENT = args.threshold_reset
 
 BOT_NAME = args.name
 SLACK_CHANNEL = args.channel
@@ -58,7 +61,7 @@ history = History(DATA_FILE)
 # Get stats from coinbase data
 # If change isn't large enough, then update history and exit
 stats = HourData(prices, EMA_NUM_HOURS)
-if Analysis.ema_checks(stats, history, EMA_THRESHOLD_PERCENT, 0.5):
+if Analysis.ema_checks(stats, history, EMA_THRESHOLD_PERCENT, EMA_RESET_PERCENT):
     sys.exit(1)
 
 if not Analysis.should_post(history, stats, prices, EMA_THRESHOLD_PERCENT):

--- a/notifier.py
+++ b/notifier.py
@@ -58,15 +58,8 @@ history = History(DATA_FILE)
 # Get stats from coinbase data
 # If change isn't large enough, then update history and exit
 stats = HourData(prices, EMA_NUM_HOURS)
-if stats.ema_percent_diff_positive < EMA_THRESHOLD_PERCENT:
-    print(f"Current price not outside threshold ({stats.formatted_info()})")
-
-    if not history.ema_reset:
-        history.ema_reset = True
-        history.save()
+if Analysis.ema_checks(stats, history, EMA_THRESHOLD_PERCENT, 0.5):
     sys.exit(1)
-
-print(f"Current price is outside threshold difference ({stats.formatted_info()})")
 
 if not Analysis.should_post(history, stats, prices, EMA_THRESHOLD_PERCENT):
     sys.exit(1)

--- a/notifier.py
+++ b/notifier.py
@@ -48,7 +48,7 @@ else:
 
 # Get data and convert accordingly
 cb = Coinbase()
-cur_price = cb.latest_price()
+cur_price = cb.latest_price
 prices = cb.price_list()
 
 # Get history from last runs, use it to work out what test to make

--- a/notifier.py
+++ b/notifier.py
@@ -68,7 +68,7 @@ if stats.ema_percent_diff_positive < EMA_THRESHOLD_PERCENT:
 
 print(f"Current price is outside threshold difference ({stats.formatted_info()})")
 
-if not Misc.should_post(history, stats, EMA_THRESHOLD_PERCENT):
+if not Misc.should_post(history, stats, prices, EMA_THRESHOLD_PERCENT):
     sys.exit(1)
 
 print("Posting to slack")

--- a/notifier.py
+++ b/notifier.py
@@ -59,8 +59,10 @@ history = History(DATA_FILE)
 stats = HourData(prices, EMA_NUM_HOURS)
 if stats.ema_percent_diff_positive < EMA_THRESHOLD_PERCENT:
     print(f"Current price not outside threshold ({stats.formatted_info()})")
-    history.ema_reset = True
-    history.save()
+
+    if not history.ema_reset:
+        history.ema_reset = True
+        history.save()
     sys.exit(1)
 
 print(f"Current price is outside threshold difference ({stats.formatted_info()})")

--- a/notifier.py
+++ b/notifier.py
@@ -5,7 +5,7 @@ from history import History
 from misc import Misc
 from coinbase import Coinbase
 from slack import Slack
-from stats import TimeIntervalData
+from stats import HourData
 from constants import SlackImages
 
 # region Argparse
@@ -56,7 +56,7 @@ history = History(DATA_FILE)
 
 # Get stats from coinbase data
 # If change isn't large enough, then update history and exit
-stats = TimeIntervalData(prices, EMA_NUM_HOURS)
+stats = HourData(prices, EMA_NUM_HOURS)
 if stats.ema_percent_diff_positive < EMA_THRESHOLD_PERCENT:
     print(f"Current price not outside threshold ({stats.formatted_info()})")
     history.ema_reset = True

--- a/notifier.py
+++ b/notifier.py
@@ -67,9 +67,10 @@ if Analysis.ema_checks(stats, history, EMA_THRESHOLD_PERCENT, EMA_RESET_PERCENT)
 if not Analysis.should_post(history, stats, prices, EMA_THRESHOLD_PERCENT):
     sys.exit(1)
 
-print("Posting to slack")
+print("Message should be posted, generating attachment")
 attachments = Slack.generate_attachment(prices, stats, EMA_NUM_HOURS)
 image_url = SlackImages.get_image(stats.is_diff_positive)
+print("Posting to slack")
 Slack.post_to_slack(BOT_NAME, image_url, "", attachments, SLACK_URL, SLACK_CHANNEL)
 
 history.price = stats.cur_price

--- a/notifier.py
+++ b/notifier.py
@@ -30,10 +30,7 @@ args = parser.parse_args()
 
 # region Constants
 # Configurable Constants
-PRIMARY_CURRENCY = "BTC"
-PRIMARY_CURRENCY_LONG = "Bitcoin"
-SECONDARY_CURRENCY = "USD"
-SECONDARY_CURRENCY_SYMBOL = "$"
+
 EMA_THRESHOLD_PERCENT = args.threshold
 EMA_NUM_HOURS = args.ema
 HOURS_BETWEEN_POSTS = args.cooldown
@@ -48,9 +45,6 @@ BOT_NAME = args.name
 SLACK_CHANNEL = args.channel
 
 # 'Hard' Constants - may rely on other values set but shouldn't be changed
-API_URL = "https://api.pro.coinbase.com"
-CANDLES_TO_RETRIEVE = 300
-CURRENCY_PAIR = f"{PRIMARY_CURRENCY}-{SECONDARY_CURRENCY}"
 SLACK_URL = args.url
 INTERNAL_DATE_FORMAT = "%d/%m/%Y - %H"
 
@@ -60,21 +54,14 @@ else:
     DATA_FILE = "last_post_data.json"
 # endregion
 
-# Time param info for request
-time_now = datetime.utcnow()
-time_start = time_now - timedelta(hours=CANDLES_TO_RETRIEVE)  # CB should give 300 results, lets make sure of it
-params = {
-    "start": time_start.isoformat(),
-    "end": time_now.isoformat(),
-    "granularity": 3600
-}
+
 
 # Current time in hours
 cur_time = datetime.utcnow()
 cur_time = cur_time.replace(minute=0, second=0, microsecond=0)
 
 # Get data and convert accordingly
-historical_data = requests.get(f"{API_URL}/products/{CURRENCY_PAIR}/candles", params=params).text
+
 cb = Coinbase(historical_data)
 cur_price = cb.latest_price()
 prices = cb.price_list()

--- a/notifier.py
+++ b/notifier.py
@@ -1,8 +1,7 @@
-import sys
 import argparse
+import sys
 
-from coinbase import Coinbase, Currency
-from history import History
+from coinbase import Coinbase
 from misc import *
 from slack import Slack
 from stats import TimeIntervalData

--- a/notifier.py
+++ b/notifier.py
@@ -18,10 +18,10 @@ parser.add_argument("--name", "-n", default="Cryptocorn",
                     help="Webhook name",)
 parser.add_argument("--ema", "-e", default=26, type=int,
                     help="Number of hours for EMA calculation")
-parser.add_argument("-i", "--interval", default=60, type=int, choices=[5, 15, 60],
+parser.add_argument("--interval", "--i", default=60, type=int, choices=[5, 15, 60],
                     help="Resolution of data to fetch from coinbase (minutes)")
 parser.add_argument("--threshold-ema", "-te", default=2.5, type=float,
-                    help="Amount current price needs to be above/below the EMA")
+                    help="Amount current price needs to be above/below the EMA to cause a post to be sent")
 parser.add_argument("--threshold-reset", "-tr", default=1.25, type=float,
                     help="Amount EMA price needs to be within last post price to reset")
 parser.add_argument("--json-name", "-j",

--- a/notifier.py
+++ b/notifier.py
@@ -48,7 +48,7 @@ else:
 
 # Get data and convert accordingly
 cb = Coinbase()
-cur_price = cb.latest_price
+cur_price = cb.latest_price()
 prices = cb.price_list()
 
 # Get history from last runs, use it to work out what test to make

--- a/notifier.py
+++ b/notifier.py
@@ -18,6 +18,8 @@ parser.add_argument("--name", "-n", default="Cryptocorn",
                     help="Webhook name",)
 parser.add_argument("--ema", "-e", default=26, type=int,
                     help="Number of hours for EMA calculation")
+parser.add_argument("-i", "--interval", default=60, type=int, choices=[5, 15, 60],
+                    help="Resolution of data to fetch from coinbase (minutes)")
 parser.add_argument("--threshold", "-t", default=2.5, type=float,
                     help="Amount current price needs to be above EMA")
 parser.add_argument("--json-name", "-j",
@@ -41,6 +43,8 @@ if args.json_name is not None:
     DATA_FILE = args.json_name
 else:
     DATA_FILE = "last_post_data.json"
+
+Coinbase.interval = args.interval
 # endregion
 
 # Get data and convert accordingly

--- a/notifier.py
+++ b/notifier.py
@@ -1,10 +1,12 @@
 import argparse
 import sys
 
+from history import History
+from misc import Misc
 from coinbase import Coinbase
-from misc import *
 from slack import Slack
 from stats import TimeIntervalData
+from constants import SlackImages
 
 # region Argparse
 parser = argparse.ArgumentParser(description="Post messages to slack if a cryptocurrency has changed price significantly")
@@ -31,19 +33,6 @@ args = parser.parse_args()
 EMA_THRESHOLD_PERCENT = args.threshold
 EMA_NUM_HOURS = args.ema
 HOURS_BETWEEN_POSTS = args.cooldown
-
-class SlackColourThresholds:
-    GOOD = 1
-    NEUTRAL = 0
-    WARNING = -1
-
-class SlackImages:
-    UP = "https://i.imgur.com/2PVZ0l1.png"
-    DOWN = "https://i.imgur.com/21sDn3D.png"
-
-    @classmethod
-    def get_image(cls, up: bool):
-        return cls.UP if up else cls.DOWN
 
 BOT_NAME = args.name
 SLACK_CHANNEL = args.channel
@@ -76,7 +65,7 @@ if stats.ema_percent_diff_positive < EMA_THRESHOLD_PERCENT:
 
 print(f"Current price is outside threshold difference ({stats.formatted_info()})")
 
-if not should_post(history, stats, EMA_THRESHOLD_PERCENT):
+if not Misc.should_post(history, stats, EMA_THRESHOLD_PERCENT):
     sys.exit(1)
 
 print("Posting to slack")
@@ -90,4 +79,3 @@ history.ema_reset = False
 history.save()
 
 print("Done")
-

--- a/slack.py
+++ b/slack.py
@@ -1,7 +1,9 @@
 import requests
 import json
 
-from misc import *
+from coinbase import Currency
+from stats import TimeIntervalData
+from misc import Misc
 
 class Slack:
     @classmethod
@@ -43,8 +45,8 @@ class Slack:
 
         # noinspection PyListCreation
         attachments = []
-        attachments.append(format_stat(stats_1_hour, stats, "Price 1 hour ago:      ", attachment_pretext))
-        attachments.append(format_stat(stats_24_hour, stats, "Price 24 hours ago:  "))
-        attachments.append(format_stat(stats_7_day, stats, "Price 7 days ago:      "))
+        attachments.append(Misc.format_stat(stats_1_hour, stats, "Price 1 hour ago:      ", attachment_pretext))
+        attachments.append(Misc.format_stat(stats_24_hour, stats, "Price 24 hours ago:  "))
+        attachments.append(Misc.format_stat(stats_7_day, stats, "Price 7 days ago:      "))
         
         return attachments

--- a/slack.py
+++ b/slack.py
@@ -7,8 +7,8 @@ from misc import Misc
 
 class Slack:
     @classmethod
-    def post_to_slack(cls, name, icon, text, attachments, slack_url, channel=""):
-        slack_data = {"username": name, "icon_url": icon, "text": text, "attachments": attachments, "channel": channel}
+    def post_to_slack(cls, name: str, icon_url: str, text: str, attachments: list, slack_url: str, channel=""):
+        slack_data = {"username": name, "icon_url": icon_url, "text": text, "attachments": attachments, "channel": channel}
         response = "null"
 
         try:

--- a/slack.py
+++ b/slack.py
@@ -53,7 +53,7 @@ class Slack:
         # noinspection PyBroadException
         try:
             price_28_days = Coinbase.price_days_ago(28)
-            attachments.append(cls.format_stat(price_28_days, stats.cur_price, "Price 28 days ago:      "))
+            attachments.append(cls.format_stat(price_28_days, stats.cur_price, "Price 28 days ago:     "))
         except Exception as e:
             print(e)
             print("Ignoring error, posting 3 historical prices instead of 4 (28 day price omitted)")

--- a/slack.py
+++ b/slack.py
@@ -35,25 +35,25 @@ class Slack:
         print(slack_data)
 
     @classmethod
-    def generate_attachment(cls, prices: list, stats: HourData, ema: int):
+    def generate_attachment(cls, prices: list, current_stats: HourData, ema: int):
         stats_1_hour = HourData(prices, ema, 1)
         stats_24_hour = HourData(prices, ema, 24)
         stats_7_day = HourData(prices, ema, 24 * 7)
 
-        sign_str = "up" if stats.is_diff_positive else "down"
-        attachment_pretext = f"{Currency.PRIMARY_CURRENCY_LONG}'s price has gone {sign_str}. Current price: {Currency.SECONDARY_CURRENCY_SYMBOL}{stats.cur_price:,.0f}"
+        sign_str = "up" if current_stats.is_diff_positive else "down"
+        attachment_pretext = f"{Currency.PRIMARY_CURRENCY_LONG}'s price has gone {sign_str}. Current price: {Currency.SECONDARY_CURRENCY_SYMBOL}{current_stats.cur_price:,.0f}"
 
         # noinspection PyListCreation
         attachments = []
-        attachments.append(cls.format_stat_wrapper(stats_1_hour, stats, "Price 1 hour ago:      ", attachment_pretext))
-        attachments.append(cls.format_stat_wrapper(stats_24_hour, stats, "Price 24 hours ago:  "))
-        attachments.append(cls.format_stat_wrapper(stats_7_day, stats, "Price 7 days ago:      "))
+        attachments.append(cls.format_stat_wrapper(stats_1_hour, current_stats, "Price 1 hour ago:      ", attachment_pretext))
+        attachments.append(cls.format_stat_wrapper(stats_24_hour, current_stats, "Price 24 hours ago:  "))
+        attachments.append(cls.format_stat_wrapper(stats_7_day, current_stats, "Price 7 days ago:      "))
 
         # Try to add 28 day stats
         # noinspection PyBroadException
         try:
             price_28_days = Coinbase.price_days_ago(28)
-            attachments.append(cls.format_stat(price_28_days, stats.cur_price, "Price 28 days ago:     "))
+            attachments.append(cls.format_stat(price_28_days, current_stats.cur_price, "Price 28 days ago:     "))
         except Exception as e:
             print(e)
             print("Ignoring error, posting 3 historical prices instead of 4 (28 day price omitted)")

--- a/slack.py
+++ b/slack.py
@@ -1,6 +1,8 @@
 import requests
 import json
 
+from misc import *
+
 class Slack:
     @classmethod
     def post_to_slack(cls, name, icon, text, attachments, slack_url, channel=""):
@@ -29,3 +31,20 @@ class Slack:
         print(response)
         print("Data sent:")
         print(slack_data)
+
+    @classmethod
+    def generate_attachment(cls, prices: list, stats: TimeIntervalData, ema: int):
+        stats_1_hour = TimeIntervalData(prices, ema, 1)
+        stats_24_hour = TimeIntervalData(prices, ema, 24)
+        stats_7_day = TimeIntervalData(prices, ema, 24 * 7)
+
+        sign_str = "up" if stats.is_diff_positive else "down"
+        attachment_pretext = f"{Currency.PRIMARY_CURRENCY_LONG}'s price has gone {sign_str}. Current price: {Currency.SECONDARY_CURRENCY_SYMBOL}{stats.cur_price:,.0f}"
+
+        # noinspection PyListCreation
+        attachments = []
+        attachments.append(format_stat(stats_1_hour, stats, "Price 1 hour ago:      ", attachment_pretext))
+        attachments.append(format_stat(stats_24_hour, stats, "Price 24 hours ago:  "))
+        attachments.append(format_stat(stats_7_day, stats, "Price 7 days ago:      "))
+        
+        return attachments

--- a/slack.py
+++ b/slack.py
@@ -2,7 +2,7 @@ import requests
 import json
 
 from coinbase import Currency
-from stats import TimeIntervalData
+from stats import HourData
 from misc import Misc
 
 class Slack:
@@ -35,10 +35,10 @@ class Slack:
         print(slack_data)
 
     @classmethod
-    def generate_attachment(cls, prices: list, stats: TimeIntervalData, ema: int):
-        stats_1_hour = TimeIntervalData(prices, ema, 1)
-        stats_24_hour = TimeIntervalData(prices, ema, 24)
-        stats_7_day = TimeIntervalData(prices, ema, 24 * 7)
+    def generate_attachment(cls, prices: list, stats: HourData, ema: int):
+        stats_1_hour = HourData(prices, ema, 1)
+        stats_24_hour = HourData(prices, ema, 24)
+        stats_7_day = HourData(prices, ema, 24 * 7)
 
         sign_str = "up" if stats.is_diff_positive else "down"
         attachment_pretext = f"{Currency.PRIMARY_CURRENCY_LONG}'s price has gone {sign_str}. Current price: {Currency.SECONDARY_CURRENCY_SYMBOL}{stats.cur_price:,.0f}"

--- a/stats.py
+++ b/stats.py
@@ -34,7 +34,7 @@ class TimeIntervalData:
         self.ema_percent_diff = percent_diff
         self.ema_percent_diff_positive = abs(percent_diff)
         self.diff = diff
-        self.diff_positive = diff > 0
+        self.is_diff_positive = diff > 0
 
     def formatted_info(self):
         return f"{self.cur_price:.0f}/{self.ema:.0f} - {self.ema_percent_diff_positive:.1f}%"

--- a/stats.py
+++ b/stats.py
@@ -16,7 +16,7 @@ class Stats:
         return current_ema
 
 """Data class to calculate stats from basic input data"""
-class TimeIntervalData:
+class HourData:
     def __init__(self, price_data, ema_num_hours, offset: int = 0):
         if offset > 0:
             price_data = price_data[offset:]


### PR DESCRIPTION
Removes cooldown algorithm and replaces it with a percentage based algorithm that should work better. The EMA now needs to be within a specified percentage of the last post price to reset things. This works with the existing checks for movement direction and intensity. The granularity of data retrieved from coinbase can be adjusted to be 5/15/60 mins, which will then be converted into an hourly list of prices.

The 28 day history was also added to the webhook message (omits if retrieval fails). The Readme needs to be updated, but that can wait for things to stabilise